### PR TITLE
Add seeding script

### DIFF
--- a/config/seeds.js
+++ b/config/seeds.js
@@ -1,0 +1,14 @@
+let seeds = {
+  Kredits: {
+    addContributor: [
+      ['0x24dd2aedd8a9fe52ac071b3a23b2fc8f225c185e', 'Hoàng Tâm', '', false, 123],
+      ['0xa502eb4021f3b9ab62f75b57a94e1cfbf81fd827', 'Terence', '', false, 2323]
+    ],
+    addProposal: [
+      ['0x24dd2aedd8a9fe52ac071b3a23b2fc8f225c185e', 23, 'http://kosmos.org', ''],
+      ['0xa502eb4021f3b9ab62f75b57a94e1cfbf81fd827', 42, 'http://kosmos.org', '']
+    ]
+  }
+};
+
+module.exports = seeds;

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "parity": "scripts/parity.sh",
     "console": "node scripts/console.js",
     "inspect": "node scripts/inspect.js",
-    "package": "scripts/package.sh"
+    "package": "scripts/package.sh",
+    "seed": "node scripts/seed.js"
   },
   "author": "Michael Bumann",
   "license": "MIT",
@@ -24,6 +25,7 @@
     "commander": "^2.9.0",
     "glob": "*",
     "solc": "*",
-    "web3": "*"
+    "web3": "*",
+    "async": "*"
   }
 }

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const pkg = require(path.join(__dirname, '../package.json'));
+const Web3 = require('web3');
+const program = require('commander');
+const util = require('util');
+const async = require('async');
+
+program
+  .version(pkg.version)
+  .option('-a, --account <account address>', 'from account address. default: web3.eth.accounts[0]')
+  .parse(process.argv);
+
+const abi = require(path.join(__dirname, '..', 'tmp/abi.js'));
+const addresses = require(path.join(__dirname, '..', 'tmp/address.js'));
+
+let web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
+web3.eth.defaultAccount = program.account || web3.eth.accounts[0];
+
+let seeds = require(path.join(__dirname, '..', '/config/seeds.js'));
+
+let contracts = {};
+Object.keys(abi).forEach((contractName) => {
+  contracts[contractName] = web3.eth.contract(abi[contractName]).at(addresses[contractName]);
+});
+
+let executors = [];
+Object.keys(seeds).forEach(contract => {
+  Object.keys(seeds[contract]).forEach(method => {
+    seeds[contract][method].forEach(args => {
+      executors.push((cb) => {
+        console.log(`[${contract}] calling ${method} with ${util.inspect(args)}`);
+        contracts[contract][method](...args, cb);
+      });
+    });
+  });
+});
+
+// execution order matters. some seeds depend on each other
+async.series(executors, (errors, responses) => {
+  console.log('\nDone seeding');
+  console.log('responses: ', responses);
+  console.log('errors: ', errors);
+});


### PR DESCRIPTION
the seed script allows to execute certain contract function to easily
setup testing data for locally deployed contracts to a development
chain.